### PR TITLE
Add support for partial credits

### DIFF
--- a/src/Message/CreditRequest.php
+++ b/src/Message/CreditRequest.php
@@ -37,7 +37,10 @@ class CreditRequest extends AbstractRequest
             'sha1' => $this->generateSignature(),
         ];
 
-        if (null !== $amount = $this->getAmountInteger()) {
+        // Only full refunds are supported with afterpay
+        if ('afterpay' !== $this->getPaymentMethod() &&
+            null !== $amount = $this->getAmountInteger()
+        ) {
             $data['amount'] = $amount;
             $data['tax'] = 2100;
             $data['exclusive'] = false;

--- a/src/Message/CreditRequest.php
+++ b/src/Message/CreditRequest.php
@@ -31,11 +31,20 @@ class CreditRequest extends AbstractRequest
     {
         $this->validate('transactionReference', 'merchantId', 'merchantKey');
 
-        return [
+        $data = [
             'trxid' => $this->getTransactionReference(),
             'merchantid' => $this->getMerchantId(),
             'sha1' => $this->generateSignature(),
         ];
+
+        if (null !== $amount = $this->getAmountInteger()) {
+            $data['amount'] = $amount;
+            $data['tax'] = 2100;
+            $data['exclusive'] = false;
+            $data['description'] = \sprintf('Refund %01.2f', $amount / 100);
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -198,17 +198,16 @@ class PurchaseRequest extends AbstractRequest
                 $data['product_id_' . $x] = $item->getName();
                 $data['product_description_' . $x] = $item->getDescription();
                 $data['product_quantity_' . $x] = $item->getQuantity();
-                $data['product_netprice_' . $x] = round(($this->formatCurrency($item->getPrice()) / 121 * 100) * 100);
+                $data['product_netprice_' . $x] = round(($this->formatCurrency($item->getPrice()) / 121) * 100 * 100);
                 $data['product_total_' . $x] = round(
                     $this->formatCurrency($item->getPrice()) * $item->getQuantity() * 100
                 );
                 $data['product_nettotal_' . $x] = round(
-                    ($this->formatCurrency($item->getPrice()) / 121 * 100) * $item->getQuantity() * 100
+                    ($this->formatCurrency($item->getPrice()) / 121) * 100 * $item->getQuantity() * 100
                 );
 
-                //@todo fix tax rates
-                $data['product_tax_' . $x] = round(($this->formatCurrency($item->getPrice()) / 121 * 21) * 100);
-                $data['product_taxrate_' . $x] = 21 * 100;
+                $data['product_tax_' . $x] = round(($this->formatCurrency($item->getPrice()) / 121) * 21 * 100);
+                $data['product_taxrate_' . $x] = 2100;
             }
         }
 

--- a/tests/Message/CreditRequestTest.php
+++ b/tests/Message/CreditRequestTest.php
@@ -49,6 +49,21 @@ class CreditRequestTest extends TestCase
         );
     }
 
+    public function testGetDataPartialForAfterpay()
+    {
+        $this->request->setPaymentMethod('afterpay');
+        $this->request->setAmountInteger(121);
+
+        self::assertSame(
+            [
+                'trxid' => '789',
+                'merchantid' => '123',
+                'sha1' => sha1('789123456'),
+            ],
+            $this->request->getData()
+        );
+    }
+
     public function testSendSuccess()
     {
         $this->setMockHttpResponse('CreditSuccess.txt');

--- a/tests/Message/CreditRequestTest.php
+++ b/tests/Message/CreditRequestTest.php
@@ -31,6 +31,24 @@ class CreditRequestTest extends TestCase
         );
     }
 
+    public function testGetDataPartial()
+    {
+        $this->request->setAmountInteger(121);
+
+        self::assertSame(
+            [
+                'trxid' => '789',
+                'merchantid' => '123',
+                'sha1' => sha1('789123456'),
+                'amount' => 121,
+                'tax' => 2100,
+                'exclusive' => false,
+                'description' => 'Refund 1.21',
+            ],
+            $this->request->getData()
+        );
+    }
+
     public function testSendSuccess()
     {
         $this->setMockHttpResponse('CreditSuccess.txt');


### PR DESCRIPTION
Note that the VAT percentage is always 21%. This is not correct of course, but has always been the case. Perhaps we should have a look at that sometime, but it is out of the scope of this PR. I corrected the calculations to avoid any issues though.